### PR TITLE
Adding comments and small refactor

### DIFF
--- a/lib/crapify.js
+++ b/lib/crapify.js
@@ -5,7 +5,8 @@ var _ = require('lodash'),
   proxy = require('monkey-proxy'),
   Throttle = require('throttle');
 
-function Crapify(opts) {
+function Crapify (opts) {
+  // set default options if none are specified.
   _.extend(this, {
     port: 5000,
     speed: 5000,
@@ -14,30 +15,12 @@ function Crapify(opts) {
   }, opts)
 }
 
-Crapify.prototype.start = function() {
+Crapify.prototype.start = function () {
   var _this = this;
 
   this.server = proxy(http.createServer(), {
-    transformRequest: [
-      function() {
-        return new CrappyStream({
-          dropFrequency: _this.dropFrequency
-        })
-      },
-      function() {
-        return new Throttle(_this.speed);
-      }
-    ],
-    transformResponse: [
-      function() {
-        return new CrappyStream({
-          dropFrequency: _this.dropFrequency
-        })
-      },
-      function() {
-        return new Throttle(_this.speed);
-      }
-    ],
+    transformRequest: [crappyStreamFactory, throttleFactory],
+    transformResponse: [crappyStreamFactory, throttleFactory],
     concurrency: this.concurrency
   });
 
@@ -48,12 +31,22 @@ Crapify.prototype.start = function() {
   this.server.on('connection', function (socket) {
     _this.socket = socket;
   });
+
+  function crappyStreamFactory () {
+    return new CrappyStream({
+      dropFrequency: _this.dropFrequency
+    });
+  }
+
+  function throttleFactory () {
+    return new Throttle(_this.speed);
+  }
 };
 
-Crapify.prototype.stop = function(cb) {
+Crapify.prototype.stop = function (cb) {
   var _this = this;
 
-  this.server.close(function() {
+  this.server.close(function () {
     _this.socket.destroy();
     return cb();
   });

--- a/lib/crappy-stream.js
+++ b/lib/crappy-stream.js
@@ -12,30 +12,38 @@ function CrappyStream (opts) {
 
 inherits(CrappyStream, Transform);
 
-CrappyStream.prototype._transform = function(chunk, encoding, next) {
-  var i = 0,
-    ii = 0,
-    buffer = new Buffer(chunk.length);
+CrappyStream.prototype._transform = function (chunk, encoding, next) {
+  if (this.dropFrequency !== 0) {
+    var i = 0,
+      ii = 0,
+      buffer = new Buffer(chunk.length);
 
-  // iterate over the bytes of a chunk with `i`, and copy a byte into
-  // a temporary buffer at location `ii` if it is not to be dropped.
-  for (; i < chunk.length; i++) {
-    this.byteCount++;
-    if (this.byteCount % this.dropFrequency === 0) {
-      continue;
+    // Iterate over the bytes of a chunk with `i`, and copy a byte into
+    // a temporary buffer at index `ii` if it is not to be dropped.
+    // Note that this method drops bytes in a uniform distribution.
+    for (; i < chunk.length; i++) {
+      this.byteCount++;
+      if (this.byteCount % this.dropFrequency === 0) {
+        continue;
+      }
+      buffer[ii] = chunk[i];
+      ii++;
     }
-    buffer[ii] = chunk[i];
-    ii++;
-  }
 
-  // since the buffer may be shorter due to dropped bytes, it is needed
-  // to slice off the unassigned bytes at the end of the buffer.
-  this.push(buffer.slice(0, ii));
+    // Since the buffer may be shorter due to dropped bytes, it is needed
+    // to slice off the unassigned bytes at the end of the buffer.
+    this.push(buffer.slice(0, ii));
+
+  } else {
+    // Skip iterating over bytes if nothing is to be dropped, just write
+    // it and get it over with.
+    this.push(chunk);
+  }
 
   return next();
 }
 
-CrappyStream.prototype._flush = function(done) {
+CrappyStream.prototype._flush = function (done) {
   return done();
 };
 

--- a/lib/crappy-stream.js
+++ b/lib/crappy-stream.js
@@ -13,10 +13,13 @@ function CrappyStream (opts) {
 inherits(CrappyStream, Transform);
 
 CrappyStream.prototype._transform = function(chunk, encoding, next) {
-  var ii = 0,
+  var i = 0,
+    ii = 0,
     buffer = new Buffer(chunk.length);
 
-  for (var i = 0; i < chunk.length; i++) {
+  // iterate over the bytes of a chunk with `i`, and copy a byte into
+  // a temporary buffer at location `ii` if it is not to be dropped.
+  for (; i < chunk.length; i++) {
     this.byteCount++;
     if (this.byteCount % this.dropFrequency === 0) {
       continue;
@@ -25,7 +28,10 @@ CrappyStream.prototype._transform = function(chunk, encoding, next) {
     ii++;
   }
 
+  // since the buffer may be shorter due to dropped bytes, it is needed
+  // to slice off the unassigned bytes at the end of the buffer.
   this.push(buffer.slice(0, ii));
+
   return next();
 }
 


### PR DESCRIPTION
Comments:
- Explains how the byte dropping works. It is a uniform distribution, could be more realistic by specifying some probability that a byte will be dropped but this would be slower. This may be a feature, after all the point is to make things slower ;)

Refactors:
- I noticed that `transformRequest` and `transformResponse` have the same functions, so I combined them.
- It skips copying bytes into a temporary buffer if dropping bytes is not needed. 
- Small syntactic fixes.

The tests should pass.
