### PR TITLE
added additional dials that we can turn on a connection

### DIFF
--- a/bin/crapify.js
+++ b/bin/crapify.js
@@ -20,6 +20,16 @@ var yargs = require('yargs')
     alias: 'concurrency',
     default: 10,
     description: 'how many concurrent connections are allowed to proxy'
+  })
+  .options('k', {
+    alias: 'close',
+    default: false,
+    description: "should 'connection: close' be set on the outbound connection"
+  })
+  .options('z', {
+    alias: 'sleep',
+    default: 0,
+    description: 'how long should crapify sleep before processing the next connection'
   }),
   chalk = require('chalk'),
   commands = {
@@ -30,7 +40,9 @@ var yargs = require('yargs')
           port: args.port,
           speed: args.speed,
           concurrency: args.concurrency,
-          dropFrequency: args['drop-frequency']
+          dropFrequency: args['drop-frequency'],
+          sleep: args.sleep,
+          close: args.close
         })).start();
       }
     },

--- a/lib/crapify.js
+++ b/lib/crapify.js
@@ -11,7 +11,9 @@ function Crapify (opts) {
     port: 5000,
     speed: 5000,
     concurrency: 10,
-    dropFrequency: 0
+    dropFrequency: 0,
+    sleep: 0,
+    close: false
   }, opts)
 }
 
@@ -21,7 +23,9 @@ Crapify.prototype.start = function () {
   this.server = proxy(http.createServer(), {
     transformRequest: [crappyStreamFactory, throttleFactory],
     transformResponse: [crappyStreamFactory, throttleFactory],
-    concurrency: this.concurrency
+    sleep: this.sleep,
+    concurrency: this.concurrency,
+    close: this.close
   });
 
   this.server.listen(this.port, function () {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "lodash": "^2.4.1",
-    "monkey-proxy": "^1.0.1",
+    "monkey-proxy": "^1.2.0",
     "throttle": "^1.0.3",
     "yargs": "^1.3.3"
   },


### PR DESCRIPTION
- you can now specify a sleep before the next connection is processed.
- you can now ensure that `connection: close` is explicitly set on the outbound connection.
